### PR TITLE
Fix mobile responsive and make site body scrollable

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     url: new URLSearchParams(location.search),
     issue: new URLSearchParams(location.search).get('issue') || new URLSearchParams(location.search).get('i') || 'list',
   }"
-    class="bg-white dark:bg-gray-700 overflow-hidden"
+    class="bg-white dark:bg-gray-700"
   >
 
     <!-- Dark/light mode switcher -->

--- a/index.html
+++ b/index.html
@@ -434,7 +434,7 @@
 
       <!-- Player controls -->
       <div id="player-container" class="flex bottom-0 left-0 w-screen h-14 p-2 z-50 bg-white dark:bg-gray-700">
-        <div class="absolute w-full inline-block flex flex-row overflow-hidden items-center">
+        <div class="w-full inline-block flex flex-row overflow-hidden items-center">
           <div class="flex p-1 ml-3">
             <!-- <button class="focus:outline-none">
               <svg class="w-4 h-4 stroke-gray-500 dark:stroke-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       }"
       x-init="list = (await (await fetch('/data/list.json')).json()).list"
     >
-      <div class="grid grid-cols-5 gap-4 p-10">
+      <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4 p-10">
       <template x-for="issue in list">
         <a :href="'/?i='+issue.id">
           <div class="block flex flex-col rounded-lg bg-white hover:bg-gray-200 p-6 shadow-[0_2px_15px_-3px_rgba(0,0,0,0.07),0_10px_20px_-2px_rgba(0,0,0,0.04)] dark:bg-gray-600 dark:hover:bg-gray-500 justify-center">


### PR DESCRIPTION
Used Tailwind features:
* https://tailwindcss.com/docs/responsive-design#targeting-a-breakpoint-range
* https://tailwindcss.com/docs/grid-template-columns

Another point: `overflow-hidden` caused non-scrollable body on any of type devices. Removing it makes body scrollable again without visible style impact.